### PR TITLE
dune_radiological_model_decay0_v3_5_for1x2x6.fcl

### DIFF
--- a/dunesim/EventGenerator/Radiological/dune_radiological_model_decay0_v3_5_for1x2x6.fcl
+++ b/dunesim/EventGenerator/Radiological/dune_radiological_model_decay0_v3_5_for1x2x6.fcl
@@ -1,0 +1,548 @@
+#include "services_dune.fcl"
+
+BEGIN_PROLOG
+# -JReichenbacher (01/11/2017)
+#  v2.01/JS: use only generator and not also arGen
+#  v2.1-02142017/JR: moved photon paddles by (0.5+0.476+0.001) cm in x
+#  v2.2-02222017/JR: cut out LAr volume inside APA around PDs (-0.477,...,0.477) cm in x
+#  v2.3-03212017/JR: include neutrons emitted from concrete of membrane cryostat structure (temporarily placed at aluminum field cage positions in sim.)
+#  v2.4-05122017/JS: Removed the LAr cut out. Added in the 210po generation near the PDs. Disabled FC (Until Neutrons can be pushed to LArData.)
+#  v2.5-05252017/JS: Added in 85Kr as a background in LAr using the WARP collaboration rates. https://arxiv.org/pdf/astro-ph/0603131.pdf
+#  v2.6-05302017/JS: Added neutronGen back in, using the Concrete_DUNE1 spectrum (by JR). New spectrum will be in dune_pardata.
+#  v2.7-06062017/JS: Added material specific generation for LAr contaminants.
+#  v2.8-06092017/JS: Reconfigured this to be an include for a typical job. This file will now host generators for the various radiologicals, but will not run a simulation itself.
+#  v3.0-19072021/Pierre Lasorak: Copy and past dune_radiological_model.fcl, and addapt to decay0
+#  v3.1-05052023/Juergen Reichenbacher: Incorporate full 10kton geometry propagated external backgrounds (Gleb Sinev's TGraphs), 232Th decay chain, 220Rn in LAr, and more conservative APA radioimpurities
+#  v3.1.1-05162023/Juergen Reichenbacher: Incorporate more and worst shotcrete case full 10kton geometry propagated external backgrounds (use Juergen's scaled and normalized TGraphs that used Gleb Sinev's background propagation sim files), 232Th decay chain, 220Rn in LAr, and more conservative APA radioimpurities
+#  v3.1.2-06132023/Juergen Reichenbacher: Increased external background rates by area factor of 1.3687 (= cryostat surface / argon surface) and foamGammas rate by 4pi/2pi correction
+#  v3.1.3-08222023/Juergen Reichenbacher: Reduced activity in APA steel to numbers measured at South Dakota (SDSMT+SURF) for APA steel sample from Daresbury production site
+#  v3.1.4-09142023/Juergen Reichenbacher: Included backgrounds from APA electronics boards based on SDSMT assays of FR4 Sussex boards and changed activity in CPA to assayed FR4 activities too (CPA->3mm =>adjusted K42&RnDaughters on CPA)
+#  v3.1.5-12112023/Juergen Reichenbacher: As APA electronics boards in geometry break Wire-Cell reco, added fix for those backgrounds, independent now of boards being present in geometry (-> dune10kt_1x2x6_gammas_in_APAboards)
+#                 /removed also historic model v2 early Rn222 daughters from the plate-out decay chain on PDS (starts now with Pb210, as pointed out by Laura Paulucci)
+
+// Drop the 1x2x6 where necessary (everything "should work")
+
+#The Generator names provided that should be called from other files are:
+#dune10kt_1x2x6_39ar     #Ar39 in LAr
+#dune10kt_1x2x6_APA      #Co60 in APA frame
+#dune10kt_1x2x6_neutron  #Originally use for K40 in Field Cage. Now repurposed for Neutrons from concrete.
+#dune10kt_1x2x6_CPA      #K40 from CPA
+#dune10kt_1x2x6_85kr     #Kr in LAr
+#dune10kt_1x2x6_222rn    #Rn in LAr
+#dune10kt_1x2x6_210po    #po for 1 cm in front of PDs (approximates effect of Rn daughters on PDs
+#
+
+dune10kt_1x2x6_weird_beta_example_in_LAr: # a dummy example
+{
+   # module_type: "Decay0Gen"
+   module_type: "SpectrumVolumeGen"
+   isotope:     "11"
+   material:    "LAr"
+   spectrum_p_min: 0
+   spectrum_p_max: 0.01
+   spectrum: [0,0,1,1,1,1,4,4,1,1,0,0]
+   ## OR
+   # spectrum_p_min: 0
+   # spectrum_p_max: 0.01
+   # nbins:100
+   # function: "[0]*x+[1]*x*x+[2]"
+   # parameters: [100,0,0]
+   ## OR
+   # spectrum: [0,1,4,4,1.5]
+   # bins: [0.,0.02,0.04,0.08,0.15,0.3]
+   ## OR
+   # bins: [0.,0.02,0.04,0.08,0.15,0.3]
+   # function: "[0]*x+[1]*x*x+[2]"
+   # parameters: [100,0,0]
+   BqPercc: 0.00141 # activity -- Becquerels per cc. 0.00141 assumes 1.01 Bq/kg (typical for 39Ar) and a density of 1.396 g/cc for LAr
+   volume_rand: "volCryostat"
+}
+
+dune10kt_85Kr_in_LAr:{
+   module_type: "Decay0Gen"
+   isotope: "Kr85"
+   volume_rand: "volCryostat"
+   material: "LAr"
+   BqPercc: 0.00016# Rate tied to LAr using rates established by the WARP collaboration. https://arxiv.org/pdf/astro-ph/0603131.pdf
+}
+
+dune10kt_39Ar_in_LAr:{
+   module_type: "Decay0Gen"
+   isotope: "Ar39"
+   volume_rand: "volCryostat"
+   material: "LAr"
+   BqPercc: 0.00141 # activity -- Becquerels per cc. 0.00141 assumes 1.01 Bq/kg (typical for 39Ar) and a density of 1.396 g/cc for LAr
+}
+
+dune10kt_42Ar_in_LAr:{
+   module_type: "Decay0Gen"
+   isotope: "Ar42"
+   volume_rand: "volCryostat"
+   material: "LAr"
+   BqPercc: 0.0000001283768 // No clue where this number comes from (see dune_radiological_model.fcl) (Thiago 2022)
+   # JReichenbacher (09/14/2023): Checked above number matching rate from paper by Barabash in conference proceeding http://iopscience.iop.org/article/10.1088/1742-6596/718/6/062004/pdf
+}
+
+dune10kt_42Kfrom42Ar_in_LAr:{
+   module_type: "Decay0Gen"
+   isotope: "K42"
+   volume_rand: "volCryostat"
+   material:    "LAr"
+   BqPercc: 0.00000002567536 // = 0.0000001283768*.2  as only 20% of the 42K stays in the Argon...
+}
+
+dune10kt_1x2x6_42Kfrom42Ar_in_CPA:{ // if somebody change the geom of the cathode, the activity will need to change (hence I didn't drop the 1x2x6 spec here)
+   module_type: "Decay0Gen"
+   isotope: "K42"
+   volume_gen: ".*Cathode.*" // The rest of the 42K go to the cathode
+   // This number was adjusted such that:
+   // The rate of decays of dune10kt_42Kfrom42Ar_in_LAr + dune10kt_1x2x6_42Kfrom42Ar_in_CPA = dune10kt_42Kfrom42Ar_in_LAr
+   // However, the decays in LAr happen over _ALL_ the LAr, but the CPA only convers 78% of the volumes in the 1x2x6,
+   // so we have to multiply bt 78% the result of the previous line.
+   #BqPercc: 0.0029 //!\\ beware this number need to change if the geometry of the cathode changes.
+   BqPercc: 0.00031 // CHANGED to 0.0000001283768*80% ionized Ar42 * 2*350cm drift collection / 0.3cm CPA thickness / 78% coverage -JReichenbacher (09/14/2023)
+}
+
+
+dune10kt_1x2x6_40K_in_CPA:{ // again beware of geometry change here
+   module_type: "Decay0Gen"
+   isotope: "K40"
+   volume_gen:".*Cathode.*"
+   material: ".*"
+   #BqPercc: 0.17
+   BqPercc: 0.0037
+   # Should be 4.9 Bq/kg (measured for 40K) times a density of 1.85 g/cc for 3 mm thick G10 -JReichenbacher (01/11/2017)
+   # However the width of the cathode in the 1x2x6 geometry is 0.016cm (?!?!), so one has to multiply by an extra factor of 0.3/0.016
+   # new SDSMT FR4 assay result on K40 is 7.0 Bq/kg and thickness of CPA changed back to 3 mm with measured density of 1.75 g/cm^3 -JReichenbacher (09/14/2023)
+}
+
+dune10kt_1x2x6_238U_chain_in_CPA:{ // again beware of geometry change here
+   module_type: "Decay0Gen"
+   volume_gen:".*Cathode.*"
+   material: ".*"
+   decay_chain:{ # ALL THESE ARE ASSUMED TO BE @ EQUILIBRIUM!!
+      isotope_0:"U238"
+      isotope_1:"Th234"
+      isotope_2:"Pa234m"
+      isotope_3:"U234"
+      isotope_4:"Th230"
+      isotope_5:"Ra226"
+      isotope_6:"Rn222"
+      isotope_7:"Po218"
+      isotope_8:"Pb214"
+      isotope_9:"Bi214"
+      isotope_10:"Pb210"
+      isotope_11:"Bi210"
+      isotope_12:"Po210"
+   }
+   #BqPercc: 2.12e-3
+   # Should be 6.105e-2 Bq/kg times a density of 1.85 g/cc for 3 mm thick G10 -JReichenbacher (01/11/2017)
+   # However the width of the cathode in the 1x2x6 geometry is 0.016cm (?!?!), so one has to multiply by an extra factor of 0.3/0.016 (checked again by JR 05/05/2023)
+   BqPercc: 2.7e-3
+   # new SDSMT FR4 assay result on lateU w/U235 correction is 5.1 Bq/kg and thickness of CPA changed back to 3 mm with measured density of 1.75 g/cm^3 -JReichenbacher (09/14/2023)
+}
+
+dune10kt_1x2x6_232Th_chain_in_CPA:{ // again beware of geometry change here
+   module_type: "Decay0Gen"
+   volume_gen:".*Cathode.*"
+   material: ".*"
+   decay_chain:{ # ALL THESE ARE ASSUMED TO BE @ EQUILIBRIUM!! Use decay_chain w/ isotope_x instead of Nuclide as a first for 232Th decay chain (JR 27Sept2022)
+      isotope_0:"Ra228"  # 232Th not yet defined in BxDecay0 (cf. https://github.com/BxCppDev/bxdecay0#list-of-standard-radioactive-isotopes-backgroundcalibration)
+      isotope_1:"Ac228"
+      isotope_2:"Pb212"  # 228Th, 224Ra, 220Rn, 216Po all not yet defined in BxDecay0
+      isotope_3:"Bi212"  # for Bi212+Po212
+      isotope_4:"Tl208"
+   }
+   BqPercc: 3.8e-3
+   # new SDSMT FR4 assay result on 232Th is 7.2 Bq/kg and thickness of CPA changed back to 3 mm with measured density of 1.75 g/cm^3 -JReichenbacher (09/14/2023)
+}
+
+
+dune10kt_1x2x6_40K_in_APAboards:{ // newly implemented gdml volume ref. as 'G10HeadBoards' -JReichenbacher (09/14/2023)
+   module_type: "Decay0Gen"
+   isotope: "K40"
+   volume_gen:".*G10HeadBoards.*"
+   material: ".*"
+   BqPercc: 0.01225
+   # new SDSMT FR4 assay result on K40 is 7.0 Bq/kg with measured density of 1.75 g/cm^3 -JReichenbacher (09/14/2023)
+}
+
+dune10kt_1x2x6_238U_chain_in_APAboards:{ // newly implemented gdml volume ref. as 'G10HeadBoards' -JReichenbacher (09/14/2023)
+   module_type: "Decay0Gen"
+   volume_gen:".*G10HeadBoards.*"
+   material: ".*"
+   decay_chain:{ # ALL THESE ARE ASSUMED TO BE @ EQUILIBRIUM!!
+      isotope_0:"U238"
+      isotope_1:"Th234"
+      isotope_2:"Pa234m"
+      isotope_3:"U234"
+      isotope_4:"Th230"
+      isotope_5:"Ra226"
+      isotope_6:"Rn222"
+      isotope_7:"Po218"
+      isotope_8:"Pb214"
+      isotope_9:"Bi214"
+      isotope_10:"Pb210"
+      isotope_11:"Bi210"
+      isotope_12:"Po210"
+   }
+   BqPercc: 8.925e-3
+   # new SDSMT FR4 assay result on lateU w/U235 correction is 5.1 Bq/kg with measured density of 1.75 g/cm^3 -JReichenbacher (09/14/2023)
+}
+
+dune10kt_1x2x6_232Th_chain_in_APAboards:{ // newly implemented gdml volume ref. as 'G10HeadBoards' -JReichenbacher (09/14/2023)
+   module_type: "Decay0Gen"
+   volume_gen:".*G10HeadBoards.*"
+   material: ".*"
+   decay_chain:{ # ALL THESE ARE ASSUMED TO BE @ EQUILIBRIUM!! Use decay_chain w/ isotope_x instead of Nuclide as a first for 232Th decay chain (JR 27Sept2022)
+      isotope_0:"Ra228"  # 232Th not yet defined in BxDecay0 (cf. https://github.com/BxCppDev/bxdecay0#list-of-standard-radioactive-isotopes-backgroundcalibration)
+      isotope_1:"Ac228"
+      isotope_2:"Pb212"  # 228Th, 224Ra, 220Rn, 216Po all not yet defined in BxDecay0
+      isotope_3:"Bi212"  # for Bi212+Po212
+      isotope_4:"Tl208"
+   }
+   BqPercc: 0.0126
+   # new SDSMT FR4 assay result on 232Th is 7.2 Bq/kg with measured density of 1.75 g/cm^3 -JReichenbacher (09/14/2023)
+}
+
+
+dune10kt_1x2x6_60Co_in_APA:{ // similar story as in the cathode
+   module_type: "Decay0Gen"
+   volume_gen:".*APA.*"
+   material: "STEEL_STAINLESS_Fe7Cr2Ni"
+   isotope: "Co60"
+   # CHANGED from  BqPercc: 3.61e-4 # 45.5 mBq/kg = 45.5e-6 Bq/g (MPIK 2008 high measurement) and a density of 7.9300 g/cm3 (from gdml)
+   # BqPercc: 1.8239e-3 # 230 mBq/kg = 23.0e-5 Bq/g (hottest steel on radiopurity.org is ILIAS Edelweiss Stainless steel, 304L) and use a density of 7.9300 g/cm3 (from gdml) -JReichenbacher (05/05/2023)
+   BqPercc: 1.0864e-3 # 137 mBq/kg = 13.7e-5 Bq/g (new measurement at South Dakota (SDSMT+SURF) for APA steel sample from Daresbury) and use a density of 7.9300 g/cm3 (from gdml) -JReichenbacher (08/22/2023)
+}
+
+dune10kt_1x2x6_238U_chain_in_APA:{ // similar story as in the cathode
+   module_type: "Decay0Gen"
+   volume_gen:".*APA.*"
+   material: "STEEL_STAINLESS_Fe7Cr2Ni"
+   decay_chain:{ # ALL THESE ARE ASSUMED TO BE @ EQUILIBRIUM!!
+      isotope_0:"U238"
+      isotope_1:"Th234"
+      isotope_2:"Pa234m"
+      isotope_3:"U234"
+      isotope_4:"Th230"
+      isotope_5:"Ra226"
+      isotope_6:"Rn222"
+      isotope_7:"Po218"
+      isotope_8:"Pb214"
+      isotope_9:"Bi214"
+      isotope_10:"Pb210"
+      isotope_11:"Bi210"
+      isotope_12:"Po210"
+   }
+   # CHANGED from  BqPercc: 9.5e-2 # 12 Bq/kg, and then very similar story as before dune10kt_1x2x6_60Co_in_APA
+   # BqPercc: 1.586e-2 # 2.0 Bq/kg (hottest steel on radiopurity.org is ILIAS UKDM steel sheet and scaffold), and then very similar story as before dune10kt_1x2x6_60Co_in_APA  -JReichenbacher (05/05/2023)
+   BqPercc: 1.6653e-4 # 21 mBq/kg (new U_late measurement at South Dakota (SDSMT+SURF) for APA steel sample from Daresbury), and then very similar story as before dune10kt_1x2x6_60Co_in_APA  -JReichenbacher (08/22/2023)
+}
+
+dune10kt_1x2x6_232Th_chain_in_APA:{ // similar story as in the cathode
+   module_type: "Decay0Gen"
+   volume_gen:".*APA.*"
+   material: "STEEL_STAINLESS_Fe7Cr2Ni"
+ decay_chain:{ # ALL THESE ARE ASSUMED TO BE @ EQUILIBRIUM!! Use decay_chain w/ isotope_x instead of Nuclide as a first for 232Th decay chain (JR 27Sept2022)
+    isotope_0:"Ra228"  # 232Th not yet defined in BxDecay0 (cf. https://github.com/BxCppDev/bxdecay0#list-of-standard-radioactive-isotopes-backgroundcalibration)
+    isotope_1:"Ac228"
+    isotope_2:"Pb212"  # 228Th, 224Ra, 220Rn, 216Po all not yet defined in BxDecay0
+    isotope_3:"Bi212"  # for Bi212+Po212
+    isotope_4:"Tl208"
+ }
+   # BqPercc: 4.8373 # 610.0 Bq/kg (hottest steel on radiopurity.org is ILIAS UKDM steel sheet and scaffold), and then very similar story as before dune10kt_1x2x6_60Co_in_APA  -JReichenbacher (05/05/2023)
+   BqPercc: 2.7914e-4 # 35.2 mBq/kg (new Th_late upper 90%CL limit measured at South Dakota (SDSMT+SURF) for APA steel sample from Daresbury), and then very similar story as before dune10kt_1x2x6_60Co_in_APA  -JReichenbacher (08/22/2023)
+}
+
+
+dune10kt_222Rn_chain_in_LAr:{
+   module_type:"Decay0Gen"
+   BqPercc: 0.000001395
+   volume_rand: "volCryostat"
+   material: "LAr"
+   decay_chain:{ # ALL THESE ARE ASSUMED TO BE @ EQUILIBRIUM!!
+      isotope_0:"Rn222"
+      isotope_1:"Po218"
+      isotope_2:"Pb214"
+      isotope_3:"Bi214"
+      isotope_4:"Pb210"
+      isotope_5:"Bi210"
+      isotope_6:"Po210"
+   }
+}
+
+dune10kt_222Rn_chain_in_PDS:{
+   module_type:"Decay0Gen"
+   # Arapucas have the following size: 2.3 x 11.8 x 209.2, this makes a total AREA of 5,953.72 cm^2
+   # 0.2 Bq/m^2 is the requirement
+   # total activity is then: 0.11907 Bq / Arapuca
+   # this translate to 0.11907/(2.3x11.8x209.2) = 0.000021 Bq/cm^3
+   BqPercc: 0.000021
+   volume_gen: ".*Arapuca.*"
+   decay_chain:{ # ALL THESE ARE ASSUMED TO BE @ EQUILIBRIUM!!
+      isotope_0:"Pb210"
+      isotope_1:"Bi210"
+      isotope_2:"Po210"
+   }
+}
+
+
+
+dune10kt_222Rn_chain_222RnOnly_in_LAr:{
+   module_type:"Decay0Gen"
+   BqPercc: 0.000001395
+   volume_rand: "volCryostat"
+   material: "LAr"
+   isotope:"Rn222"
+}
+
+
+dune10kt_222Rn_chain_218PoOnly_in_LAr:{
+   @table::dune10kt_222Rn_chain_222RnOnly_in_LAr
+   isotope:"Po218"
+   BqPercc: 0.000001203885 # Rn222 rate minus the 13.7% on the cathode
+   distrib_x: "936.088+2.81714*TMath::Abs(x)-0.00403933*x*x-1.24485e-06*TMath::Power(TMath::Abs(x),3)"
+}
+dune10kt_222Rn_chain_218PoOnly_in_CPA:{
+   @table::dune10kt_222Rn_chain_218PoOnly_in_LAr
+   volume_gen: ".*Cathode.*"
+   material: @erase
+   #BqPercc:0.00528
+   BqPercc: 5.717e-4 // CHANGED to 0.000001395*13.7% ions * 2*350cm drift collection / 0.3cm CPA thickness / 78% coverage -JReichenbacher (09/14/2023)
+   distrib_x: @erase
+}
+
+
+dune10kt_222Rn_chain_214PbOnly_in_LAr:{
+   @table::dune10kt_222Rn_chain_222RnOnly_in_LAr
+   isotope:"Pb214"
+   BqPercc: 0.000000827235 # Rn222 rate minus the 40.7% on the cathode
+   distrib_x: "590.016+1.83392*TMath::Abs(x)+0.00012101*x*x-5.42539e-06*TMath::Power(TMath::Abs(x),3)"
+}
+dune10kt_222Rn_chain_214PbOnly_in_CPA:{
+   @table::dune10kt_222Rn_chain_214PbOnly_in_LAr
+   volume_gen: ".*Cathode.*"
+   material: @erase
+   #BqPercc:0.015678
+   BqPercc: 1.6984e-3 // CHANGED to 0.000001395*40.7% ions * 2*350cm drift collection / 0.3cm CPA thickness / 78% coverage -JReichenbacher (09/14/2023)
+   distrib_x: @erase
+}
+
+
+dune10kt_222Rn_chain_214BiOnly_in_LAr:{
+   @table::dune10kt_222Rn_chain_222RnOnly_in_LAr
+   isotope:"Bi214"
+   BqPercc:0.00000045756 # Rn222 rate minus the 67.2% on the cathode
+   distrib_x: "263.835+1.32691*TMath::Abs(x)-0.000128904*x*x-1.64996e-06*TMath::Power(TMath::Abs(x),3)"
+}
+dune10kt_222Rn_chain_214BiOnly_in_CPA:{
+   @table::dune10kt_222Rn_chain_214BiOnly_in_LAr
+   volume_gen: ".*Cathode.*" // The rest of the 42K go to the cathode
+   material: @erase
+   #BqPercc:0.025886
+   BqPercc: 2.8043e-3 // CHANGED to 0.000001395*67.2% ions * 2*350cm drift collection / 0.3cm CPA thickness / 78% coverage -JReichenbacher (09/14/2023)
+   distrib_x: @erase
+}
+
+
+dune10kt_222Rn_chain_210PbOnly_in_LAr:{
+   @table::dune10kt_222Rn_chain_222RnOnly_in_LAr
+   isotope:"Pb210"
+   BqPercc:0.00000045756 # Rn222 rate minus the 67.2% on the cathode
+   distrib_x:"259.482+1.58444*TMath::Abs(x)-0.00214077*x*x+1.95097e-06*TMath::Power(TMath::Abs(x),3)"
+}
+dune10kt_222Rn_chain_210PbOnly_in_CPA:{
+   @table::dune10kt_222Rn_chain_210PbOnly_in_LAr
+   volume_gen: ".*Cathode.*" // The rest of the 42K go to the cathode
+   material: @erase
+   #BqPercc:0.025886
+   BqPercc: 2.8043e-3 // CHANGED to 0.000001395*67.2% (shouldn't this be 80% ???) ions * 2*350cm drift collection / 0.3cm CPA thickness / 78% coverage -JReichenbacher (09/14/2023)
+   distrib_x: @erase
+}
+
+
+dune10kt_222Rn_chain_from210Bi_in_CPA:{
+   @table::dune10kt_222Rn_chain_210PbOnly_in_CPA
+   #BqPercc:0.0385
+   BqPercc: 2.8043e-3 // CHANGED to same new number as for 210Pb in CPA b/c 210Bi is 210Pb daughter and assume decay products stay in CPA -JReichenbacher (09/14/2023)
+   isotope: @erase
+   decay_chain:{ # ALL THESE ARE ASSUMED TO BE @ EQUILIBRIUM!!
+      isotope_0:"Bi210"
+      isotope_1:"Po210"
+   }
+}
+
+
+dune10kt_220Rn_chain_212PbOnly_in_LAr:{
+   @table::dune10kt_222Rn_chain_222RnOnly_in_LAr
+   BqPercc:0.00000015252 # 0.00000045756 of Rn222 divided by 3 for Rn220 rate minus the 67.2% on the cathode (not sure about x-distribution/rate -JReichenbacher 05/16/2023)
+   isotope: @erase
+ decay_chain:{ # ALL THESE ARE ASSUMED TO BE @ EQUILIBRIUM!! Use decay_chain w/ isotope_x instead of Nuclide as a first for 232Th decay chain (JR 27Sept2022)
+    isotope_0:"Pb212"  # 228Th, 224Ra, 220Rn, 216Po all not yet defined in BxDecay0 (cf. https://github.com/BxCppDev/bxdecay0#list-of-standard-radioactive-isotopes-backgroundcalibration)
+    isotope_1:"Bi212"  # for Bi212+Po212
+    isotope_2:"Tl208"
+ }
+   distrib_x:"259.482+1.58444*TMath::Abs(x)-0.00214077*x*x+1.95097e-06*TMath::Power(TMath::Abs(x),3)"
+}
+
+
+dune10kt_220Rn_chain_from212Pb_in_CPA:{
+   @table::dune10kt_222Rn_chain_210PbOnly_in_CPA // not sure if that is most appropriate but it works
+   volume_gen: ".*Cathode.*" // for now only consider what goes to the cathode
+   material: @erase
+   #BqPercc:0.0128 # 0.0385 from 222Rn decay chain divided by 3 corresponding to SD Mines assay results for ProtoDUNE Cu-getter and mol-sieve filter materials  -JReichenbacher (05/05/2023)
+   BqPercc: 9.348e-4 # 2.8043e-3 from 222Rn decay chain divided by 3 corresponding to SD Mines assay results for ProtoDUNE Cu-getter and mol-sieve filter materials  -JReichenbacher (09/14/2023)
+   distrib_x: @erase
+   isotope: @erase
+ decay_chain:{ # ALL THESE ARE ASSUMED TO BE @ EQUILIBRIUM!! Use decay_chain w/ isotope_x instead of Nuclide as a first for 232Th decay chain (JR 27Sept2022)
+    isotope_0:"Pb212"  # 228Th, 224Ra, 220Rn, 216Po all not yet defined in BxDecay0 (cf. https://github.com/BxCppDev/bxdecay0#list-of-standard-radioactive-isotopes-backgroundcalibration)
+    isotope_1:"Bi212"  # for Bi212+Po212
+    isotope_2:"Tl208"
+ }
+}
+
+
+// **********************
+// *** NOT USED in v3 *** only kept for historical reasons! ("NeutronGenInRock: @local::dune10kt_1x2x6_neutron_from_rock"  is commented out in producer file)
+// **********************
+// This is copied straight from dune_radiological_model.fcl v1 and was used for v2 but NOT anymore for v3!
+// This is MASSIVELY dependant on the geometry
+dune10kt_1x2x6_neutron_from_rock: // Center region is added to simulate neutrons comming in from the rock at the outermost APAs (on the edge of the cryostat) per J. Reichenbacher's request. This should more accurately represent the worst case scenario in the FD.
+{
+   module_type:           "RadioGen"
+   Nuclide:               ["Concrete_DUNE10MeV", "Concrete_DUNE10MeV", "Concrete_DUNE10MeV", "Concrete_DUNE10MeV", "Concrete_DUNE10MeV" ]
+   Material:              [".*",".*",".*",".*", ".*"]
+   BqPercc:               [ 0.0000076, 0.0000076, 0.0000076, 0.0000076, 0.0000076 ] # activity -- Becquerels per cc. 0.0000076 assumes 10 neutrons/y/g per 10 ppm U-238 in concrete and a density of 2.40 g/cc for 10 cm mean depth in concrete -JReichenbacher (03/21/2017)
+   T0:                    [ -2246000.,-2246000.,-2246000.,-2246000.,-2246000 ] # ending time in ns
+   T1:                    [  2246000., 2246000., 2246000., 2246000., 2246000 ] # ending time in ns
+   
+   X0:                    [    0. ,    0. ,    0.,    0.,   -0.5 ] # in cm in world coordinates, bottom corner of box
+   X1:                    [  350. ,  350. ,  350.,  350.,    0.5 ] # in cm in world coordinates, top corner of box
+   Y0:                    [ -600. , -600. , -601.,  600., -600.  ] # in cm in world coordinates, bottom corner of box
+   Y1:                    [  600. ,  600. , -600.,  601.,  600.  ] # in cm in world coordinates, top corner of box
+   Z0:                    [   -0.5, 1394.5,    0.,    0.,    0.  ] # in cm in world coordinates, bottom corner of box
+   Z1:                    [    0.5, 1395.5, 1395., 1395., 1395.  ] # in cm in world coordinates, top corner of box
+}
+// ****************************
+// *** ABOVE NOT USED in v3 *** only kept for historical reasons! ("NeutronGenInRock: @local::dune10kt_1x2x6_neutron_from_rock"  is commented out in producer file)
+// ****************************
+
+
+// This is MASSIVELY dependent on the geometry
+dune10kt_1x2x6_gammas_from_cavernwall_atLAr: // Convinced myself again that best is to have only one 1cm thin vertical center plane at inner APA to emulate external backgrounds comming in through cryostat (and not at the CPAs that are unrealistically positioned on the outside in the 1x2x6), and then two 1cm thin planes on top and bottom both 25cm offset from TPC, and similarly at both faces. This should more accurately represent the worst case scenario in the FD HD. - J. Reichenbacher (05/05/2023)
+{
+   module_type:           "RadioGen"
+   Nuclide:               ["CavernGammasAtLArFlux", "CavernGammasAtLArFlux", "CavernGammasAtLArFlux", "CavernGammasAtLArFlux", "CavernGammasAtLArFlux"] # downscaled above 3.3 MeV for overestimated (alpha, gamma) production in Geant4 -JReichenbacher (05/16/2023)
+   Material:              [".*",".*",".*",".*",".*"]
+   BqPercc:               [ 1.05104, 1.05104, 1.05104, 1.05104, 1.05104 ] # activity -- Becquerels per cc. 1.05104 assumes 4pi flux of 0.25597 gammas/(cm^2 sec) at LAr interface propagated from cavernwalls (rock+shotcrete SDSMT assay data) and impact factor 3.0 (~4x shotcrete activity) applied due to our worst case shotcrete we appear to get from our recent shotcrete assays and area factor of 1.3687 -JReichenbacher (06/13/2023)
+   T0:                    [ -2246000.,-2246000.,-2246000.,-2246000.,-2246000 ] # starting time in ns
+   T1:                    [  2246000., 2246000., 2246000., 2246000., 2246000 ] # ending time in ns
+   
+   X0:                    [ -375. , -375. , -375., -375.,    -0.5 ] # in cm in world coordinates, low x-values of planes
+   X1:                    [  375. ,  375. ,  375.,  375.,     0.5 ] # in cm in world coordinates, high x-values of planes
+   Y0:                    [ -625. , -625. , -625.5, 624.5, -625.  ] # in cm in world coordinates, low y-values of planes
+   Y1:                    [  625. ,  625. , -624.5, 625.5,  625.  ] # in cm in world coordinates, high y-values of planes
+   Z0:                    [  -25.5, 1419.5,  -25.,  -25.,   -25.  ] # in cm in world coordinates, low z-values of planes
+   Z1:                    [  -24.5, 1420.5, 1420., 1420.,  1420.  ] # in cm in world coordinates, high z-values of planes
+}
+
+
+// This is MASSIVELY dependent on the geometry
+dune10kt_1x2x6_gammas_from_foam_atLAr: // Convinced myself again that best is to have only one 1cm thin vertical center plane at inner APA to emulate external backgrounds comming in through cryostat (and not at the CPAs that are unrealistically positioned on the outside in the 1x2x6), and then two 1cm thin planes on top and bottom both 25cm offset from TPC, and similarly at both faces. This should more accurately represent the worst case scenario in the FD HD. - J. Reichenbacher (05/05/2023)
+{
+   module_type:           "RadioGen"
+   Nuclide:               ["foamGammasAtLArFlux", "foamGammasAtLArFlux", "foamGammasAtLArFlux", "foamGammasAtLArFlux", "foamGammasAtLArFlux"] # downscaled above 3.3 MeV for overestimated (alpha, gamma) production in Geant4 -JReichenbacher (05/16/2023)
+   Material:              [".*",".*",".*",".*",".*"]
+   BqPercc:               [ 0.0441274, 0.0441274, 0.0441274, 0.0441274, 0.0441274 ] # activity -- Becquerels per cc. is 4pi flux of 0.0441274 gammas/(cm^2 sec) at LAr interface propagated from R-PUF foam (ICPMS PNNL assay data from C. Jackson) -JReichenbacher (06/13/2023)
+   T0:                    [ -2246000.,-2246000.,-2246000.,-2246000.,-2246000 ] # starting time in ns
+   T1:                    [  2246000., 2246000., 2246000., 2246000., 2246000 ] # ending time in ns
+   
+   X0:                    [ -375. , -375. , -375., -375.,    -0.5 ] # in cm in world coordinates, low x-values of planes
+   X1:                    [  375. ,  375. ,  375.,  375.,     0.5 ] # in cm in world coordinates, high x-values of planes
+   Y0:                    [ -625. , -625. , -625.5, 624.5, -625.  ] # in cm in world coordinates, low y-values of planes
+   Y1:                    [  625. ,  625. , -624.5, 625.5,  625.  ] # in cm in world coordinates, high y-values of planes
+   Z0:                    [  -25.5, 1419.5,  -25.,  -25.,   -25.  ] # in cm in world coordinates, low z-values of planes
+   Z1:                    [  -24.5, 1420.5, 1420., 1420.,  1420.  ] # in cm in world coordinates, high z-values of planes
+}
+
+
+// This is MASSIVELY dependent on the geometry
+dune10kt_1x2x6_neutrons_from_cavernwall_atLAr: // Convinced myself again that best is to have only one 1cm thin vertical center plane at inner APA to emulate external backgrounds comming in through cryostat (and not at the CPAs that are unrealistically positioned on the outside in the 1x2x6), and then two 1cm thin planes on top and bottom both 25cm offset from TPC, and similarly at both faces. This should more accurately represent the worst case scenario in the FD HD. - J. Reichenbacher (05/05/2023)
+{
+   module_type:           "RadioGen"
+   Nuclide:               ["CavernNeutronsAtLArFlux", "CavernNeutronsAtLArFlux", "CavernNeutronsAtLArFlux", "CavernNeutronsAtLArFlux", "CavernNeutronsAtLArFlux"]
+   Material:              [".*",".*",".*",".*",".*"]
+   BqPercc:               [ 0.00000026996, 0.00000026996, 0.00000026996, 0.00000026996, 0.00000026996 ] # activity -- Becquerels per cc. 0.00000026996 assumes 4pi flux of 0.00000009862 neutrons/(cm^2 sec) at LAr interface propagated from cavernwalls (rock+shotcrete SDSMT assay data) and impact factor 2.0 (less than for gammas, ~4x shotcrete activity) applied due to our worst case shotcrete we appear to get from our recent shotcrete assays and area factor of 1.3687 -JReichenbacher (06/13/2023)
+   T0:                    [ -2246000.,-2246000.,-2246000.,-2246000.,-2246000 ] # starting time in ns
+   T1:                    [  2246000., 2246000., 2246000., 2246000., 2246000 ] # ending time in ns
+   
+   X0:                    [ -375. , -375. , -375., -375.,    -0.5 ] # in cm in world coordinates, low x-values of planes
+   X1:                    [  375. ,  375. ,  375.,  375.,     0.5 ] # in cm in world coordinates, high x-values of planes
+   Y0:                    [ -625. , -625. , -625.5, 624.5, -625.  ] # in cm in world coordinates, low y-values of planes
+   Y1:                    [  625. ,  625. , -624.5, 625.5,  625.  ] # in cm in world coordinates, high y-values of planes
+   Z0:                    [  -25.5, 1419.5,  -25.,  -25.,   -25.  ] # in cm in world coordinates, low z-values of planes
+   Z1:                    [  -24.5, 1420.5, 1420., 1420.,  1420.  ] # in cm in world coordinates, high z-values of planes
+}
+
+
+// This is MASSIVELY dependent on the geometry
+dune10kt_1x2x6_CryostatNGammas_from_CavernNeutrons_atLAr: // Convinced myself again that best is to have only one 1cm thin vertical center plane at inner APA to emulate external backgrounds comming in through cryostat (and not at the CPAs that are unrealistically positioned on the outside in the 1x2x6), and then two 1cm thin planes on top and bottom both 25cm offset from TPC, and similarly at both faces. This should more accurately represent the worst case scenario in the FD HD. - J. Reichenbacher (05/05/2023)
+{
+   module_type:           "RadioGen"
+   Nuclide:               ["CryostatNGammasAtLArFluxFromCavernNeutrons", "CryostatNGammasAtLArFluxFromCavernNeutrons", "CryostatNGammasAtLArFluxFromCavernNeutrons", "CryostatNGammasAtLArFluxFromCavernNeutrons", "CryostatNGammasAtLArFluxFromCavernNeutrons"]
+   Material:              [".*",".*",".*",".*",".*"]
+   BqPercc:               [ 0.0000016793, 0.0000016793, 0.0000016793, 0.0000016793, 0.0000016793 ] # activity -- Becquerels per cc. 0.0000016793 assumes 4pi flux of 0.00000061347 Ngammas/(cm^2 sec) at LAr interface stemming from n-captures in cryostat due to propagated cavernwall neutrons (rock+shotcrete SDSMT assay data) and impact factor 2.0 (less than for caverngammas, ~4x shotcrete activity) applied due to our worst case shotcrete we appear to get from our recent shotcrete assays and area factor of 1.3687 -JReichenbacher (06/13/2023)
+   T0:                    [ -2246000.,-2246000.,-2246000.,-2246000.,-2246000 ] # starting time in ns
+   T1:                    [  2246000., 2246000., 2246000., 2246000., 2246000 ] # ending time in ns
+   
+   X0:                    [ -375. , -375. , -375., -375.,    -0.5 ] # in cm in world coordinates, low x-values of planes
+   X1:                    [  375. ,  375. ,  375.,  375.,     0.5 ] # in cm in world coordinates, high x-values of planes
+   Y0:                    [ -625. , -625. , -625.5, 624.5, -625.  ] # in cm in world coordinates, low y-values of planes
+   Y1:                    [  625. ,  625. , -624.5, 625.5,  625.  ] # in cm in world coordinates, high y-values of planes
+   Z0:                    [  -25.5, 1419.5,  -25.,  -25.,   -25.  ] # in cm in world coordinates, low z-values of planes
+   Z1:                    [  -24.5, 1420.5, 1420., 1420.,  1420.  ] # in cm in world coordinates, high z-values of planes
+}
+
+
+// This is MASSIVELY dependent on the geometry
+dune10kt_1x2x6_CavernNGammas_atLAr: // Convinced myself again that best is to have only one 1cm thin vertical center plane at inner APA to emulate external backgrounds comming in through cryostat (and not at the CPAs that are unrealistically positioned on the outside in the 1x2x6), and then two 1cm thin planes on top and bottom both 25cm offset from TPC, and similarly at both faces. This should more accurately represent the worst case scenario in the FD HD. - J. Reichenbacher (05/05/2023)
+{
+   module_type:           "RadioGen"
+   Nuclide:               ["CavernNGammasAtLArFlux", "CavernNGammasAtLArFlux", "CavernNGammasAtLArFlux", "CavernNGammasAtLArFlux", "CavernNGammasAtLArFlux"]
+   Material:              [".*",".*",".*",".*",".*"]
+   BqPercc:               [ 0.0000005439, 0.0000005439, 0.0000005439, 0.0000005439, 0.0000005439 ] # activity -- Becquerels per cc. 0.0000005439 assumes 4pi flux of 0.0000001987 Ngammas/(cm^2 sec) at LAr interface propagated through cryostat stemming from n-captures in rock+shotcrete (SDSMT assay data) and impact factor 2.0 (for n-captures less than for direct caverngammas, ~4x shotcrete activity) applied due to our worst case shotcrete we appear to get from our recent shotcrete assays and area factor of 1.3687 -JReichenbacher (06/13/2023)
+   T0:                    [ -2246000.,-2246000.,-2246000.,-2246000.,-2246000 ] # starting time in ns
+   T1:                    [  2246000., 2246000., 2246000., 2246000., 2246000 ] # ending time in ns
+   
+   X0:                    [ -375. , -375. , -375., -375.,    -0.5 ] # in cm in world coordinates, low x-values of planes
+   X1:                    [  375. ,  375. ,  375.,  375.,     0.5 ] # in cm in world coordinates, high x-values of planes
+   Y0:                    [ -625. , -625. , -625.5, 624.5, -625.  ] # in cm in world coordinates, low y-values of planes
+   Y1:                    [  625. ,  625. , -624.5, 625.5,  625.  ] # in cm in world coordinates, high y-values of planes
+   Z0:                    [  -25.5, 1419.5,  -25.,  -25.,   -25.  ] # in cm in world coordinates, low z-values of planes
+   Z1:                    [  -24.5, 1420.5, 1420., 1420.,  1420.  ] # in cm in world coordinates, high z-values of planes
+}
+
+
+dune10kt_1x2x6_gammas_in_APAboards:  // 3.81 cm thick (2*4*4.76 mm), 16.5 cm in the vertical direction, and as wide as the APA frames on top of upper APAs and bottom of lower APAs - J. Reichenbacher (12/11/2023)
+{
+   module_type:           "RadioGen"
+   Nuclide:               ["Uranium_238_chain_dominantGammaOnly_JR", "Uranium_238_chain_dominantGammaOnly_JR", "Thorium_232_chain_dominantGammaOnly_JR", "Thorium_232_chain_dominantGammaOnly_JR", "K_40_dominantGammaOnly_JR", "K_40_dominantGammaOnly_JR"]
+   Material:              [".*",".*",".*",".*",".*",".*"]
+   BqPercc:               [ 0.0197377, 0.0197377, 0.0353206, 0.0353206, 0.00129237, 0.00129237 ] # activity -- Becquerels per cc. with measured density of 1.75 g/cm^3 and multiplied with integral chain emission rate of TGraphs -JReichenbacher (12/11/2023)
+   T0:                    [ -2246000.,-2246000.,-2246000.,-2246000.,-2246000.,-2246000. ] # starting time in ns
+   T1:                    [  2246000., 2246000., 2246000., 2246000., 2246000., 2246000. ] # ending time in ns
+   
+   X0:                    [   -2. ,   -2. ,   -2. ,   -2. ,   -2. ,   -2. ] # in cm in world coordinates, low x-values of planes
+   X1:                    [    2. ,    2. ,    2. ,    2. ,    2. ,    2. ] # in cm in world coordinates, high x-values of planes
+   Y0:                    [  601. , -617. ,  601. , -617. ,  601. , -617. ] # in cm in world coordinates, low y-values of planes
+   Y1:                    [  617. , -601. ,  617. , -601. ,  617. , -601. ] # in cm in world coordinates, high y-values of planes
+   Z0:                    [    0. ,    0. ,    0. ,    0. ,    0. ,    0. ] # in cm in world coordinates, low z-values of planes
+   Z1:                    [ 1395. , 1395. , 1395. , 1395. , 1395. , 1395. ] # in cm in world coordinates, high z-values of planes
+}
+# integral gamma activity in U238 decay chain:  8.925e-3 Bq/cc * 2.21151 gammas/chain = 0.0197377  BqPercc
+# integral gamma activity in Th232 decay chain: 0.0126   Bq/cc * 2.80322 gammas/chain = 0.0353206  BqPercc
+# integral gamma activity in K40 decay:         0.01225  Bq/cc * 0.1055  gammas/decay = 0.00129237 BqPercc
+
+
+END_PROLOG


### PR DESCRIPTION
Revision v3_5 for new assays based 'Radiological Model v3' for HD 1x2x6, HD 1x2x2 and VD 1x8x6 (requiring corresponding producer files).  [As APA electronics boards in geometry break Wire-Cell reco, added fix for those backgrounds, independent now of boards being present in geometry] -Juergen Reichenbacher (SDSMT) 2023/12/11